### PR TITLE
Removed useless parameter in a test configuration file

### DIFF
--- a/tests/fixtures/full_auth_passwd.yaml
+++ b/tests/fixtures/full_auth_passwd.yaml
@@ -1,6 +1,5 @@
 ---
   url: "https://company.atlassian.net"
-  rsa_cert_file: "../tests/fixtures/full.yaml"
   auth_method: "basic"
   username: "user"
   password: "passwd"


### PR DESCRIPTION
Thank you for your prompt merge of previous PR.
Sorry I embedded a useless parameter in the configuration file for unit test at the previous PR. This removes it.